### PR TITLE
COMP: Add CTest timeout option for GitHub CI

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -5,6 +5,8 @@ on: [push,pull_request]
 jobs:
   cxx-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@03626a23c22246e89e36c7e918a158c440f9b099
+    with:
+      ctest-options: '--timeout 300'
 
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@03626a23c22246e89e36c7e918a158c440f9b099

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.16.3)
 project(Elastix)
 
+if(NOT CMAKE_CXX_STANDARD)
+  # SuperElastix/elastix uses C++17 specific features in some of its header files.
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 # To ease enablement with Python packaging
 if(DEFINED ENV{ELASTIX_USE_OPENCL})
   set(ELASTIX_USE_OPENCL ON CACHE BOOL "Enable OpenCL support in Elastix")
@@ -51,7 +56,7 @@ if(SKBUILD)
 endif()
 
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "d652938573e5f193955908eba225a854b31ce36a")
+set(elastix_GIT_TAG "b9ea3a8e65a3e015a5a0f06acfb5bd22fad8dacc")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}

--- a/wrapping/itkElastixRegistrationMethod.wrap
+++ b/wrapping/itkElastixRegistrationMethod.wrap
@@ -1,4 +1,4 @@
 itk_wrap_class("itk::ElastixRegistrationMethod" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_REAL}" 2)
+  itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2)
 itk_end_wrap_class()
 

--- a/wrapping/itkTransformixFilter.wrap
+++ b/wrapping/itkTransformixFilter.wrap
@@ -1,4 +1,4 @@
 itk_wrap_class("itk::TransformixFilter" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_REAL}" 1)
+  itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 1)
 itk_end_wrap_class()
 


### PR DESCRIPTION
Some tests can fail sometimes due to timing out at about a minute.